### PR TITLE
Bumping Siddhi version to M106 & adding configs for auto release of docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,29 @@
         </dependencies>
     </dependencyManagement>
 
+    <profiles>
+    <profile>
+        <id>documentation-deploy</id>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.wso2.siddhi</groupId>
+                    <artifactId>siddhi-doc-gen</artifactId>
+                    <version>${siddhi.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>deploy-mkdocs-github-pages</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -72,11 +95,20 @@
                 <version>${siddhi.version}</version>
                 <executions>
                     <execution>
+                        <phase>compile</phase>
                         <goals>
                             <goal>generate-md-docs</goal>
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <preparationGoals>clean install -Pdocumentation-deploy</preparationGoals>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -90,7 +122,7 @@
         </pluginManagement>
     </build>
     <properties>
-        <siddhi.version>4.0.0-M78</siddhi.version>
+        <siddhi.version>4.0.0-M104</siddhi.version>
         <wso2event.mapper.bundle.version>4.0.0.M5-SNAPSHOT</wso2event.mapper.bundle.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         </pluginManagement>
     </build>
     <properties>
-        <siddhi.version>4.0.0-M104</siddhi.version>
+        <siddhi.version>4.0.0-M106</siddhi.version>
         <wso2event.mapper.bundle.version>4.0.0.M5-SNAPSHOT</wso2event.mapper.bundle.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
## Purpose
To Make GitHub io site auto deploy on gh-pages.
To standardize the extension build profile

## Approach
Update the siddhi version to 106.
Add relevant plugins and profile to pom file to make site auto deploy on gh-pages in release build.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes