### PR TITLE
Adding default encoding as UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,8 @@
         <carbon.analytics.version>2.0.38</carbon.analytics.version>
         <testng.version>6.9.4</testng.version>
         <jacoco.version>0.7.9</jacoco.version>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Purpose
Fix build due to encoding issue.

## Approach
Adding UTF-8 as encoding in properties

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes