### PR TITLE
Moved carbon databridge to use carbon.analytics-common.

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.analytics</groupId>
+            <groupId>org.wso2.carbon.analytics-common</groupId>
             <artifactId>org.wso2.carbon.databridge.commons</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
                 <version>${log4j.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.analytics</groupId>
+                <groupId>org.wso2.carbon.analytics-common</groupId>
                 <artifactId>org.wso2.carbon.databridge.commons</artifactId>
-                <version>${carbon.analytics.version}</version>
+                <version>${carbon.analytics-common.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>
@@ -123,11 +123,11 @@
     </build>
     <properties>
         <siddhi.version>4.0.0-alpha</siddhi.version>
-        <wso2event.mapper.bundle.version>4.0.0.M5-SNAPSHOT</wso2event.mapper.bundle.version>
+        <wso2event.mapper.bundle.version>4.0.6-SNAPSHOT</wso2event.mapper.bundle.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <junit.version>4.12</junit.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
-        <carbon.analytics.version>2.0.38</carbon.analytics.version>
+        <carbon.analytics-common.version>6.0.6</carbon.analytics-common.version>
         <testng.version>6.9.4</testng.version>
         <jacoco.version>0.7.9</jacoco.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## Purpose
> Release the extension with the latest carbon.analytics-common version.

## Goals
> Moved carbon databridge to use carbon.analytics-common. 